### PR TITLE
added statsd decorator and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,34 @@ def bar():
 	
 if __name__ == '__main__':
     service_name = 'foo'
-    flask_server.start_service(app, service_name)	
+    flask_server.start_service(app, service_name)
+```	
 
+## errors.py
+Decorator for forwarding uncaught exceptions to Bugsnag
+
+Usage:
+
+```python
+@with_bugsnag
+def foo():
+    ...
+```
+
+Requires the following env vars:
+
++ `BUGSNAG_RELEASE_STAGE` (e.g., live/dev/stage)
++ `BUGSNAG_API_KEY`
+
+
+## metrics.py
+Decorator for forwarding flask endpoint response code counts and timing info to statsd
+
+Usage:
+
+```python
+@app.route('foo')
+@with_metrics
+def foo():
+   ...
+``` 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,16 @@ Usage:
 def foo():
    ...
 ``` 
+
+Requires the following env vars:
+
++ `METRICS_HOST`
++ `METRICS_HOST_PORT`
++ `RELEASE_STAGE` (e.g., live/dev/stage)
++ `SERVICE_NAME` 
+
+Response code counters are named like so:
+`{SERVICE_NAME}.{MODULE_NAME}.{FUNCTION_NAME}.{RESPONSE_CODE}`
+
+Timers are named like so:
+`{SERVICE_NAME}.{MODULE_NAME}.{FUNCTION_NAME}.response_time_ms`

--- a/flutil/metrics.py
+++ b/flutil/metrics.py
@@ -1,0 +1,35 @@
+import time
+import os
+from functools import wraps
+
+import statsd
+
+
+METRICS_HOST = os.getenv('METRICS_HOST', '52.72.43.118')
+METRICS_PORT = int(os.getenv('METRICS_HOST_PORT', 8125))
+RELEASE_STAGE = os.getenv('RELEASE_STAGE', 'undefined')
+SERVICE_NAME = os.getenv('SERVICE_NAME', 'undefined')
+PREFIX = '{}.{}'.format(RELEASE_STAGE, SERVICE_NAME)
+_statsd_client = statsd.StatsClient(METRICS_HOST, METRICS_PORT, PREFIX)
+
+
+def with_metrics(function_to_wrap):
+    """
+    Add this decorator to any Flask route to forward response times and status code counters.
+    Note: be sure this decorator is placed below Flask's @app.route decorator
+    """
+    endpoint = '{}.{}'.format(function_to_wrap.__module__, function_to_wrap.__name__)
+
+    @wraps(function_to_wrap)
+    def wrapped_endpoint(*args, **kwargs):
+        t = time.time()
+        retval = function_to_wrap(*args, **kwargs)
+        response_time_ms = (time.time() - t) * 1000
+        status_code = retval[1] if retval else 500  # if wrapped function doesn't return a value, flask is gonna spout a 500
+
+        _statsd_client.timing('{}.response_time_ms'.format(endpoint), response_time_ms)
+        _statsd_client.gauge('{}.{}'.format(endpoint, status_code), 1, delta=True)
+
+        return retval
+
+    return wrapped_endpoint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
+backports.ssl-match-hostname==3.5.0.1
 bugsnag==2.3.1
-psycopg2>=2.6.1
-tornado==4.0.2
+certifi==2016.2.28
 Flask==0.10.1
+itsdangerous==0.24
+Jinja2==2.8
+MarkupSafe==0.23
 pika==0.10.0
+psycopg2==2.6.1
+statsd==3.2.1
+tornado==4.0.2
+WebOb==1.6.0
+Werkzeug==0.11.9


### PR DESCRIPTION
This PR adds a decorator for Flask routes that forwards response code counts and timing to statsd.   It also adds missing documentation for the existing `@with_bugsnag` decorator

@whalesalad 