### PR TITLE
Flask is not needed in this project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 backports.ssl-match-hostname==3.5.0.1
 bugsnag==2.3.1
 certifi==2016.2.28
-Flask==0.10.1
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
The `flask_server.py` file is actually just a wrapper to boot any arbitrary WSGI-style application and does not import Flask. This removes the dependency to simplify the dep tree of parent projects.